### PR TITLE
Update webkitgtk parameter to webkitgtk_6_0 for compatibility with latest nixpkgs

### DIFF
--- a/nix/default.nix
+++ b/nix/default.nix
@@ -25,7 +25,7 @@
 , stdenv
 , systemd
 , typos
-, webkitgtk
+, webkitgtk_6_0
 , wrapGAppsHook
 , xdg-utils
 , xvfb-run
@@ -88,7 +88,7 @@ let
       gtk3
       libappindicator
       librsvg
-      webkitgtk
+      webkitgtk_6_0
     ];
 
     # runtime dependencies / binaries prepended to PATH


### PR DESCRIPTION
This PR updates the `webkitgtk` nix parameter to `webkitgtk_6_0` to align with the changes made to nixpkgs. The previous attribute name `webkitgtk` has been removed from nixpkgs, and using it would result in a build error: "error: 'webkitgtk' attribute has been removed from nixpkgs, use attribute with ABI version set explicitly".

This change fixes the build issue and ensures that the Ulauncher flake can be successfully built with the current version of nixpkgs.

**Changes:**
- Updated `webkitgtk` parameter to `webkitgtk_6_0` in `nix/default.nix`

**Testing:** The build should now succeed with the latest version of nixpkgs. You can verify this by running `nix build` or `nix flake build` after applying this PR.